### PR TITLE
⚠️Major update: Data update onClick

### DIFF
--- a/backend/controllers/cluster.controller.js
+++ b/backend/controllers/cluster.controller.js
@@ -1,11 +1,14 @@
+const Species = require('../models/Species');
 const Cluster = require('../models/Cluster');
 const { getCountryCoordinates } = require('../services/geo.service');
 const { getOccurrencesByCountryBatch } = require('../services/populate.service');
 const { getGbifCountryData } = require('../services/gbif.service');
+const speciesController = require('./species.controller');
+
 const countries = require("i18n-iso-countries");
 const worldCountries = require('world-countries');
+const { getContinentName } = require('@brixtol/country-continent');
 countries.registerLocale(require("i18n-iso-countries/langs/en.json"));
-
 
 //Ranking de categorias IUCN, determina la peor categoria de las especies del cluster y el color del cluster en el front-end.
 const categoryRanking = {
@@ -15,7 +18,38 @@ const categoryRanking = {
 };
 
 
-// Funcion para calcular el tamaño del marcador segun el area del pais usando escala logaritmica (mas pequeño para paises isleños, por ejemplo, mas grande para paises grandes, China o Rusia, por ejemplo)
+/**
+* Funcion deprecada utilizada en la generacin inicial de los clusters y especies. Calcula cuantos occurrences estan asociados a una especie desde la base de datos occurrences.db obtenida de GBIF.
+*/
+exports.updateAllClusterOccurrences = async (req, res) => {
+  try {
+    // 1. Traer todos los clusters y sus country codes
+    const clusters = await Cluster.find().select('country');
+    const countryCodes = clusters.map(c => c.country);
+    
+    // 2. Obtener todos los conteos de ocurrencias
+    const counts = await getOccurrencesByCountryBatch(countryCodes);
+    
+    // 3. Actualizar en MongoDB
+    const updates = clusters.map(c => 
+      Cluster.updateOne(
+        { country: c.country },
+        { $set: { occurrences: counts[c.country] || 0 } }
+      )
+    );
+    await Promise.all(updates);
+    
+    res.json({ message: 'Clusters actualizados con occurrences', counts });
+  } catch (err) {
+    console.error('Error actualizando occurrences:', err);
+    res.status(500).json({ error: 'No se pudo actualizar occurrences' });
+  }
+};
+
+
+/**
+* Funcion para calcular el tamaño del marcador segun el area del pais usando escala logaritmica (mas pequeño para paises isleños, por ejemplo, mas grande para paises grandes, China o Rusia, por ejemplo)
+*/
 exports.computeMarkerSize = async (countryCode) => {
   const countryData = worldCountries.find(c => c.cca2 === countryCode);
   if (!countryData || !countryData.area) {
@@ -29,7 +63,9 @@ exports.computeMarkerSize = async (countryCode) => {
 };
 
 
-// Funcion para actualizar el cluster de una especie
+/**
+* Funcion utilizada para actualizar el cluster. Principalmente utilizada al crear una nueva especie en el proceso de generacion inicial de la base de datos. Se encarga de validar si el cluster existe para el territorio/pais, y agrega todas las propiedades necesarias para el cluster, como la cantidad de especies y la peor categoria de las especies en ese cluster. Si el cluster no existe, lo crea y lo guarda en la base de datos.
+*/
 exports.updateClusterForSpecies = async (input, res = null) => {
   try {
     const species = input.body ? input.body : input;
@@ -45,7 +81,7 @@ exports.updateClusterForSpecies = async (input, res = null) => {
       console.log(`Actualizando cluster para ${countryCode}, ${countries.getName(countryCode, "en")}`);
       
       const markerSize = await exports.computeMarkerSize(countryCode);
-
+      
       if (!cluster) {
         const center = getCountryCoordinates(countryCode);
         const centerLat = center ? center.lat : loc.lat;
@@ -88,63 +124,6 @@ exports.updateClusterForSpecies = async (input, res = null) => {
 };
 
 
-exports.updateClusterStatusFromAPI = async (req, res) => {
-  try {
-    //1. Saco el countryCode desde la ruta
-    const countryCode = req.params.countryCode;
-
-    //2. Con el countryCode, consulto a la API de GBIF para obtener el total de occurrences de ese pais.
-    const data = await getGbifCountryData(countryCode);
-    const count = data.occurrences.count;
-
-    //3. Actualizo el cluster en la DB con el nuevo conteo de occurrences.
-    const updated = await Cluster.findOneAndUpdate(
-      { country: countryCode },
-      {
-        $set: { occurrences: count },
-        $currentDate: { updatedAt: true }
-      },
-      { new: true, select: '-__v' }
-    );
-
-    //4. Devuelvo ambas al front
-    res.json({
-      cluster: updated,
-      gbif:    data.occurrences
-    });
-  } catch (error) {
-    console.error("Error en updateClusterStatusFromAPI:", error);
-    res.status(500).json({ error: "Error interno en GBIF" });
-  }
-};
-
-
-exports.updateAllClusterOccurrences = async (req, res) => {
-  try {
-    // 1. Traer todos los clusters y sus country codes
-    const clusters = await Cluster.find().select('country');
-    const countryCodes = clusters.map(c => c.country);
-
-    // 2. Obtener todos los conteos de ocurrencias
-    const counts = await getOccurrencesByCountryBatch(countryCodes);
-
-    // 3. Actualizar en MongoDB
-    const updates = clusters.map(c => 
-      Cluster.updateOne(
-        { country: c.country },
-        { $set: { occurrences: counts[c.country] || 0 } }
-      )
-    );
-    await Promise.all(updates);
-
-    res.json({ message: 'Clusters actualizados con occurrences', counts });
-  } catch (err) {
-    console.error('Error actualizando occurrences:', err);
-    res.status(500).json({ error: 'No se pudo actualizar occurrences' });
-  }
-};
-
-
 exports.getSpeciesClusters = async (req, res) => {
   try {
     const clusters = await Cluster.find().sort({ country: 1 });
@@ -154,3 +133,217 @@ exports.getSpeciesClusters = async (req, res) => {
     res.status(500).json({ error: "Error al obtener clusters" });
   }
 };
+
+
+/**
+* 0. Funcion central encargada de actualizar el cluster desde la API. Si el usuario hizo click en un cluster y ese cluster no ha sido actualizado en cierto tiempo, se llama a esta funcion para actualizarlo.
+* @returns {Object} resultado con los nuevos datos a actualizar en la base de datos.
+*/
+exports.updateClusterStatusFromAPI = async (req, res) => {
+  try {
+    //console.log(`[cluster.controller - updateClusterStatusFromAPI] Payload recibido:`, req.body);
+    const { country: countryCode, updatedAt, id } = req.body;
+    
+    //0. Validacion basica de que llegue el countryCode y el id del cluster a actualizar.
+    if (!countryCode) {
+      console.error(`[cluster.controller - updateClusterStatusFromAPI] Missing countryCode`);
+      return res.status(400).json({ error: 'Falta el countryCode' });
+    }
+    
+    //1. Calcular rango de fechas, utilizando la fecha de hoy y la fecha de la ultima actualizacion del cluster. Se utiliza el formato YYYY-MM-DD para la consulta a GBIF.
+    const [dateRangeMin, dateRangeMax] = computeDateRange(updatedAt);
+    
+    //2. Consulta inicial al endpoint de GBIF para obtener el total de ocurrences desde la ultima actualizacion del cluster, y asi poder calcular la paginacion para las siguientes consultas.
+    const initial = await getGbifCountryData(countryCode, dateRangeMin, dateRangeMax, 0, 0);
+    const totalCount = initial.count;
+    console.log(`[cluster.controller - updateClusterStatusFromAPI] totalCount: ${totalCount}`);
+    
+    //3.Hago las consultas paginadas para obtener todos los ocurrences, y concatenar en un solo array.
+    const gbifResults = await getPaginatedGbifResults(countryCode, dateRangeMin, dateRangeMax, totalCount);
+    
+    // 4. Para cada occurrence, realizar las validaciones correspondientes.
+    for (const occurrence of gbifResults) {
+      console.log(`   [cluster.controller - updateClusterStatusFromAPI] Processing occurrence`);
+      const { taxonKey, decimalLatitude, decimalLongitude, countryCode: cc, gbifID: occurrenceId } = occurrence;
+      
+      //4.1 Valido si la especie existe en la base de datos con el taxonKey del result
+      const species = await Species.findOne({ taxon_id: taxonKey });
+      if (!species) {
+        
+        //4.1.1 Si no existe, creo y guardo en la base de datos.
+        const {kingdom, phylum, class: className, order, family, genus} = occurrence;
+        console.error(`   [cluster.controller - updateClusterStatusFromAPI] Species not found for taxonKey: ${taxonKey}, creating...`);
+        
+        //4.1.2 Generar la estructura de la nueva especie
+        const newSpecies = {
+          body: {
+            taxon_id: taxonKey,
+            scientific_name: occurrence.scientificName || `taxon_${taxonKey}`,
+            category: occurrence.iucnRedListCategory || 'CR',
+            kingdom,
+            phylum,
+            class: className,
+            order,
+            family,
+            genus,
+            locations: [{
+              country:    countryCode,
+              continent:  getContinentName(countryCode),
+              lat:         decimalLatitude,
+              lng:         decimalLongitude
+            }]
+          }
+        };
+        
+        //4.1.3 Delegar la creacion de la especie con la estructura generada a la funcion createSpecies del controller de especies.
+        await speciesController.createSpecies(newSpecies, res);
+        
+        continue;
+      }
+      
+      // 4.2 Validar si ya tiene location en el pais
+      const exists = species.locations.some(loc => loc.country === countryCode);
+      if (exists) {
+        //4.2.1 Si existe, ignoro.
+        console.log(`   [cluster.controller - updateClusterStatusFromAPI] Species ${taxonKey} already has location in this cluster. Skipping...`);
+      } else {
+        //4.2.2 Si no existe, agregar location
+        console.log(`   [cluster.controller - updateClusterStatusFromAPI] Species ${taxonKey} does not have a location in this cluster, creating.`);
+        species.locations.push({
+          country: countryCode,
+          continent: getContinentName(countryCode),
+          lat: decimalLatitude,
+          lng: decimalLongitude
+        });
+        console.log(`   [cluster.controller - updateClusterStatusFromAPI] Location successfully created.`);
+      }
+      
+      // 4.3 Validar si ya tiene el occurrenceId en gbifIds. Si no tiene, agregar
+      if (!species.gbifIds.includes(String(occurrenceId))) {
+        species.gbifIds.push(String(occurrenceId));
+        console.log(`   [cluster.controller - updateClusterStatusFromAPI] gbifId ${occurrenceId} added to species ${taxonKey}.`);
+      } else {
+        console.log(`   [cluster.controller - updateClusterStatusFromAPI] gbifId ${occurrenceId} already present in species ${taxonKey}.`);
+      }
+      
+      await species.save();
+    }
+    
+    //5. Habiendo creado las especies/locations, actualizo la cantidad de especies en el cluster y la categoria de la peor especie.
+    const infoResult = await updateSpeciesCountAndWorstCategory(id);
+    console.log(`[cluster.controller - updateClusterStatusFromAPI] Cluster updated successfully.`);
+    
+    //6. Devolver al front
+    res.json({
+      message: 'Cluster actualizado',
+      infoUpdate: infoResult
+    });
+    
+  } catch (error) {
+    console.error("[cluster.controller - updateClusterStatusFromAPI] Error updating cluster: ", error);
+    res.status(500).json({ error: "Error interno al actualizar el cluster" });
+  }
+};
+
+
+/**
+* 1. Funcion encargada de calcular el rango de fechas para la consulta a GBIF. Se utiliza la fecha de la ultima actualizacion del cluster y la fecha actual.
+* @param {String} dateRangeMin - Ultima fecha de actualizacion del pais (YYYY-MM-DD).
+* @param {String} dateRangeMax - Fecha actual (YYYY-MM-DD).
+* @returns {Object} Array con el rango de fechas minimo y maximo.
+*/
+function computeDateRange(updatedAt) {
+  const min = new Date(updatedAt).toISOString().split('T')[0];
+  const max = new Date().toISOString().split('T')[0];
+  return [min, max];
+}
+
+
+/**
+* 3. Funcion encargada de realizar las consultas paginadas a GBIF para obtener todos los ocurrences, y concatenar en un solo array.
+* @param {String} countryCode - Codigo del pais a consultar en GBIF.
+* @param {String} dateRangeMin - Ultima fecha de actualizacion del pais (YYYY-MM-DD).
+* @param {String} dateRangeMax - Fecha actual (YYYY-MM-DD).
+* @param {Number} totalCount - Cantidad total de ocurrences obtenidos desde GBIF para el pais consultado, utilizado para calcular la cantidad de paginas a consultar.
+* @returns {Object} Array con todos los occurrences obtenidos desde GBIF para el pais consultado, desde la ultima fecha de actualizacion del cluster hasta la fecha de hoy.
+*/
+async function getPaginatedGbifResults(countryCode, dateRangeMin, dateRangeMax, totalCount) {
+  
+  //3.1 Teniendo el total, calculo la cantidad total de consultas paginadas a realizar (limite de 300 registros por pagina, establecido por GBIF)    
+  const PAGE_SIZE = 300;
+  const pages = Math.ceil(totalCount / PAGE_SIZE);
+  let allResults = [];
+  console.log(`[cluster.controller - updateClusterStatusFromAPI] Pages calculated: ${pages}`);
+  
+  //3.2 Realizo las consultas paginadas a GBIF para obtener todos los ocurrences, y concatenar en un solo array.
+  for (let page = 0; page < pages; page++) {
+    const offset   = page * PAGE_SIZE;
+    console.log(`   [cluster.controller - updateClusterStatusFromAPI] Querying page ${page + 1} of ${pages}.`);
+    const pageData = await getGbifCountryData(countryCode, dateRangeMin, dateRangeMax, PAGE_SIZE, offset);
+    allResults = allResults.concat(pageData.results);
+  }
+  
+  return allResults;
+}
+
+
+/**
+* Funcion encargada de actualizar el cluster segun datos de las especies. Calcula cuantas especies tienen un location en ese cluster, y obtiene la categoria de la peor especie en dicho pais (CR, EW, EX).
+* @returns {Object} Cluster actualizado con la cantidad de especies y la peor categoria.
+*/
+async function updateSpeciesCountAndWorstCategory(clusterId) {
+  try {
+    if (!clusterId) {
+      console.error(`   [cluster.controller - updateSpeciesCountAndWorstCategory] Missing clusterId.`);
+      return { updated: false, reason: 'Falta clusterId' };
+    }
+    
+    // Buscar el cluster
+    const cluster = await Cluster.findById(clusterId);
+    if (!cluster) {
+      console.error(`   [cluster.controller - updateSpeciesCountAndWorstCategory] Cluster not found.`);
+      return { updated: false, reason: 'Cluster no encontrado' };
+    }
+    
+    const { country } = cluster;
+    if (!country) {
+      console.error(`   [cluster.controller - updateSpeciesCountAndWorstCategory] Cluster is missing country.`);
+      return { updated: false, reason: 'Cluster sin country' };
+    }
+    
+    // Buscar todas las species que tienen location en este país
+    const speciesList = await Species.find({ 'locations.country': country }, 'category');
+    
+    if (!speciesList.length) {
+      console.warn(`   [cluster.controller - updateSpeciesCountAndWorstCategory] No species found for cluster ${clusterId} (${country})`);
+      return { updated: false, reason: 'No hay especies en este país' };
+    }
+    
+    // Contar la cantidad de especies
+    const totalSpecies = speciesList.length;
+    
+    // Determinar la peor categoría
+    const priority = { CR: 1, EW: 2, EX: 3 };
+    let worstCategory = 'CR'; // default
+    speciesList.forEach(species => {
+      const cat = species.category?.toUpperCase();
+      if (cat && priority[cat] && priority[cat] > priority[worstCategory]) {
+        worstCategory = cat;
+      }
+    });
+    
+    // Actualizar el cluster
+    cluster.count = totalSpecies;
+    cluster.category = worstCategory;
+    cluster.updatedAt = new Date();
+    await cluster.save();
+    
+    console.log(`   [cluster.controller - updateSpeciesCountAndWorstCategory] Cluster updated successfully: ${clusterId}, ${country}, count: ${totalSpecies}, worstCategory: ${worstCategory}`);
+    
+    return { updated: true, count: totalSpecies, category: worstCategory };
+    
+  } catch (error) {
+    console.error(`   [cluster.controller - updateSpeciesCountAndWorstCategory] Error updating cluster:`, error);
+    return { updated: false, reason: error.message };
+  }
+}

--- a/backend/controllers/species.controller.js
+++ b/backend/controllers/species.controller.js
@@ -22,6 +22,9 @@ const {
 const sanitizeHtml = require('sanitize-html');
 
 
+/**
+* Funcion deprecada, utilizada en la creacion de la base de datos de produccion con el dataset original. Centraliza toda la logica de creacion de especie, consultando las distintas bases de datos utilizadas para obtener todos los datos de las especies originales, como media, description, locations y mas.
+*/
 exports.populateSpecies = async (req, res) => {
   try {
     const requiredFields = {
@@ -116,6 +119,9 @@ exports.populateSpecies = async (req, res) => {
 };
 
 
+/**
+* Funcion general sin uso actual, se encarga de obtener y devolver todas las especies de la base de datos, paginadas y ordenadas por fecha de creacion.
+*/
 exports.getAllSpecies = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
@@ -142,6 +148,9 @@ exports.getAllSpecies = async (req, res) => {
 };
 
 
+/**
+* Funcion general sin uso actual, se encarga de obtener y devolver una especie en particular de la base de datos, a partir de su id.
+*/
 exports.getSpeciesById = async (req, res) => {
   try {
     const species = await Species.findById(req.params.id);
@@ -155,6 +164,9 @@ exports.getSpeciesById = async (req, res) => {
 };
 
 
+/**
+* Funcion general utilizada en el front-end, se encarga de obtener y devolver todas las especies de un pais en particular, utilizando countryCode para cargar las especies y devolverlas para mostrar en el globo.
+*/
 exports.getSpeciesByCountry = async (req, res) => {
   try {
     const country = req.params.country.toUpperCase();
@@ -171,6 +183,9 @@ exports.getSpeciesByCountry = async (req, res) => {
 };
 
 
+/**
+* Funcion general utilizada en el front-end, se encarga de buscar especies utilizando los terminos recibidos desde el front, buscando especies segun su common_name o scientific_name.
+*/
 exports.searchSpecies = async (req, res) => {
   console.log('[SEARCH] Query parameters:', req.query);
   
@@ -238,9 +253,55 @@ exports.searchSpecies = async (req, res) => {
 
 
 /**
- * 0. Funcion central encargada de actualizar la especie desde la API. Si el usuario hizo click en una especie y esa especie no ha sido actualizada en cierto tiempo, se llama a esta funcion para actualizarla. Entre esto, se actualiza su categoria, common_name, media y description.
- * @returns {Object} resultado con los nuevos datos a actualizar en la base de datos.
- */
+* Funcion encargada de crearuna nueva especie en la base de datos. Esta funcion es llamada principalmente desde cluster.controller, cuando se encuentra una especie nueva en el pais. Se encarga de almacenar los campos obligatorios y luego llama a la funcion updateSpeciesStatusFromAPI para obtener media, description y common_name.
+* @returns {Object} resultado con los nuevos datos a actualizar en la base de datos.
+*/
+exports.createSpecies = async (req, res) => {
+  //Desde cualquier lugar, deberia llegar minimo taxonKey, iucnRedListCategory, species (scientific_name) y genus. Almaceno esos datos, y con ellos se consulta los endpoints de IUCN y GBIF a traves de updateSpeciesStatusFromAPI para obtener el resto de los datos. Adicionalmente, deberia llegar un location desde cluster.controller.
+  try {
+    const {
+      taxon_id,
+      scientific_name,
+      category,
+      kingdom, phylum, class: cls, order, family, genus,
+      locations
+    } = req.body;
+    
+    if (!taxon_id || !scientific_name || !category || !locations?.length) {
+      return res.status(400).json({ error: 'Faltan campos obligatorios para creación de especie' });
+    }
+    
+    // 2) Crear documento inicial
+    const newSpecie = await Species.create({
+      taxon_id,
+      scientific_name,
+      category,
+      kingdom, phylum, class: cls, order, family, genus,
+      gbifIds: [],
+      locations,
+      media: [],
+      references: [],
+      common_name: 'Unknown',
+      description: {}
+    });
+    
+    // 3) Actualizar desde APIs (media, description, common_name, taxonomy si aplica)
+    await exports.updateSpeciesStatusFromAPI({ body: { id: newSpecie._id, taxon_id, category } }, res);
+    
+    // 4) Responder con la especie creada
+    return res.status(201).json(newSpecie);
+    
+  } catch (error) {
+    console.error('[createSpecies] error:', error);
+    return res.status(500).json({ error: error.message });
+  }
+};
+
+
+/**
+* 0. Funcion central encargada de actualizar la especie desde la API. Si el usuario hizo click en una especie y esa especie no ha sido actualizada en cierto tiempo, se llama a esta funcion para actualizarla. Entre esto, se actualiza su categoria, common_name, media y description.
+* @returns {Object} resultado con los nuevos datos a actualizar en la base de datos.
+*/
 exports.updateSpeciesStatusFromAPI = async (req, res) => {
   try {
     const speciesData = req.body;
@@ -249,23 +310,23 @@ exports.updateSpeciesStatusFromAPI = async (req, res) => {
     if (!id || !taxon_id) {
       return res.status(400).json({ error: 'Falta id o taxon_id' });
     }
-
+    
     //1. Validar IUCN category
     console.log("[species.controller - updateSpeciesStatusFromAPI] 1. Validating category. Current: ", category);
     const categoryResult = await validateSpeciesIucnCategory(id, taxon_id);
-
+    
     //2. Validar common_name
     console.log("[species.controller - updateSpeciesStatusFromAPI] 2. Validating vernacular names.");
     const vernacularResult = await validateVernacularName(id, taxon_id);
-
+    
     //3. Validar media
     console.log("[species.controller - updateSpeciesStatusFromAPI] 3. Validating media");
     const mediaResult = await validateSpeciesMedia(id, taxon_id);
-
+    
     //4. Validar description
     console.log("[species.controller - updateSpeciesStatusFromAPI] 4. Validating description");
     const descriptionResult = await validateSpeciesDescription(id);
-
+    
     return res.json({
       message: 'Especie actualizada',
       category: categoryResult,
@@ -273,7 +334,7 @@ exports.updateSpeciesStatusFromAPI = async (req, res) => {
       media: mediaResult,
       description: descriptionResult,
     });
-
+    
   } catch (error) {
     console.error('[species.controller - updateSpeciesStatusFromAPI] Error al actualizar estado de especie:', error);
     res.status(500).json({ error: 'Error interno al actualizar especie' });
@@ -282,19 +343,19 @@ exports.updateSpeciesStatusFromAPI = async (req, res) => {
 
 
 /**
- * 1. Obtiene la categoría de la Lista Roja de IUCN desde GBIF y actualiza el campo category.
- * @returns {Object} resultado con la categoría anterior y la nueva
- */
+* 1. Obtiene la categoría de la Lista Roja de IUCN desde GBIF y actualiza el campo category.
+* @returns {Object} resultado con la categoría anterior y la nueva
+*/
 async function validateSpeciesIucnCategory(id, taxon_id) {
   //1.1 Busco la especie en la DB
   const species = await Species.findById(id);
   if (!species) throw new Error('Especie no encontrada');
-
+  
   //1.2 Siempre actualizo el estado de la especie con el endpoint de GBIF
   const gbif = await getGbifSpeciesRedListCategory(taxon_id);
   const newCode = gbif.code;
   console.log("   [species.controller - validateSpeciesIucnCategory] New category: ", newCode);
-
+  
   //1.3 Actualizo unicamente si la categoria nueva es distinta a la actual
   if (typeof newCode === 'string' && newCode !== species.category) {
     const before = species.category;
@@ -302,29 +363,29 @@ async function validateSpeciesIucnCategory(id, taxon_id) {
     await species.save();
     return { updated: true, field: 'category', before, after: newCode };
   }
-
+  
   return { updated: false, field: 'category', current: species.category };
 }
 
 
 /**
- * 2. Si la especie no tiene common_name o es 'Unknown', obtiene un vernacular name de GBIF y actualiza el documento.
- * @returns {Object} resultado con el nuevo common_name o null si no cambió
- */
+* 2. Si la especie no tiene common_name o es 'Unknown', obtiene un vernacular name de GBIF y actualiza el documento.
+* @returns {Object} resultado con el nuevo common_name o null si no cambió
+*/
 async function validateVernacularName(id, taxon_id) {
   //2.1 Busco la especie en la DB
   const species = await Species.findById(id);
   if (!species) throw new Error('Especie no encontrada');
-
+  
   //2.2 Valido si la especie ya tiene un common_name, de ser asi, ignoro.
   if (species.common_name && species.common_name !== 'Unknown') {
     console.log("   [species.controller - validateSpeciesIucnCategory] Species already has common_name");
     return { updated: false, field: 'common_name', current: species.common_name };
   }
-
+  
   //2.3 Si la especie no tiene common_name, obtengo una lista de los vernacularNames desde GBIF
   const gbif = await getGbifSpeciesVernacularName(taxon_id);
-
+  
   //2.4 Obtengo el primer common_name en ingles, de no existir, guardo el primero de cualquier idioma
   const eng = gbif.results.find(n => n.language === 'eng');
   const pick = eng ? eng.vernacularName : gbif.results[0]?.vernacularName;
@@ -335,7 +396,7 @@ async function validateVernacularName(id, taxon_id) {
     console.log("   [species.controller - validateSpeciesIucnCategory] New common_name: ", pick);
     return { updated: true, field: 'common_name', before, after: pick };
   }
-
+  
   return { updated: false, field: 'common_name', current: species.common_name };
 }
 
@@ -348,13 +409,13 @@ async function validateSpeciesMedia(id, taxon_id) {
   //3.1 Busco la especie en la DB
   const species = await Species.findById(id);
   if (!species) throw new Error('Especie no encontrada');
-
+  
   //3.2 Si la especie ya tiene media asociada, ignoro.
   if (species.media && species.media.length > 0) {
     console.log("   [species.controller - validateSpeciesMedia] Species already has media.");
     return { updated: false, field: 'media', current: species.media.length };
   }
-
+  
   //3.3 Si la especie no tiene media, obtengo una lista de los medios desde GBIF
   const gbif = await getGbifSpeciesMedia(taxon_id);
   const mappedMedia = gbif.results.map(media => ({
@@ -369,7 +430,7 @@ async function validateSpeciesMedia(id, taxon_id) {
     rightsHolder: '',
     license: media.references || ''
   }));
-
+  
   //3.4 Actualizo unicamente si hay algo que agregar
   if (mappedMedia.length > 0) {
     species.media = mappedMedia;
@@ -377,7 +438,7 @@ async function validateSpeciesMedia(id, taxon_id) {
     await species.save();
     return { updated: true, field: 'media', added: mappedMedia.length };
   }
-
+  
   return { updated: false, field: 'media', added: 0 };
 }
 
@@ -400,13 +461,13 @@ async function validateSpeciesDescription(id) {
     console.log("   [species.controller - validateSpeciesDescription]ERROR: Genus or scientific_name are missing:", { genus, sciName });
     return { updated: false, reason: 'No genus or scientific_name found' };
   }
-
+  
   //4.3-Construyo el nombre científico para la búsqueda con genus y scientific_name
   const prefix = genus + ' ';
   const speciesPart = sciName.startsWith(prefix)
-    ? sciName.slice(prefix.length)
-    : sciName;
-
+  ? sciName.slice(prefix.length)
+  : sciName;
+  
   //4.4-Llamo al endpoint de description para obtener una lista de los assessments mas recientes
   const data = await getIucnSpeciesDescriptionByScientificName(genus, speciesPart);
   
@@ -418,7 +479,7 @@ async function validateSpeciesDescription(id) {
   }
   const assessmentDetail = await getIucnSpeciesAssessmentById(firstAssessment.assessment_id);
   const doc = assessmentDetail.documentation || {};
-
+  
   //4.6-Defino los campos que voy a reemplazar
   const mapping = {
     rationale: 'rationale',
@@ -430,10 +491,10 @@ async function validateSpeciesDescription(id) {
     use_trade: 'useTrade',
     measures: 'conservationActions'
   };
-
+  
   //4.6.1-Validar que description existe
   species.description = {};
-
+  
   //4.7-Reemplazo en la base de datos los campos no nulos que haya devuelto la API
   for (const [docKey, modelKey] of Object.entries(mapping)) {
     const raw = doc[docKey];
@@ -445,11 +506,12 @@ async function validateSpeciesDescription(id) {
       }
     }
   }
-
+  
   console.log("   [species.controller - validateSpeciesDescription] Updated species with new documentation from IUCN.");
   await species.save();
   return { updated: true, fields: Object.values(mapping) };
 }
+
 
 //Funcion encargada de limpiar el texto de caracteres no deseados. Principalmente usada antes de guardar description, ya que los resultados desde la API vienen con tags HTML y otros elementos no deseados.
 function cleanText(input = '') {

--- a/backend/models/Cluster.js
+++ b/backend/models/Cluster.js
@@ -15,11 +15,6 @@ const clusterSchema = new mongoose.Schema({
         required: true,
         default: 0
     },
-    occurrences: {
-        type: Number,
-        required: true,
-        default: 0
-    },
     lat: {
         type: Number,
         required: true

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -34,6 +34,7 @@
         "morgan": "^1.10.0",
         "papaparse": "^5.5.2",
         "progress": "^2.0.3",
+        "qs": "^6.14.0",
         "sanitize-html": "^2.16.0",
         "sqlite3": "^5.1.7",
         "turf": "^3.0.14",
@@ -2472,6 +2473,21 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3173,6 +3189,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fast-csv": {
@@ -4781,12 +4812,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "morgan": "^1.10.0",
     "papaparse": "^5.5.2",
     "progress": "^2.0.3",
+    "qs": "^6.14.0",
     "sanitize-html": "^2.16.0",
     "sqlite3": "^5.1.7",
     "turf": "^3.0.14",

--- a/backend/routes/cluster.routes.js
+++ b/backend/routes/cluster.routes.js
@@ -7,9 +7,9 @@ const {
     updateClusterStatusFromAPI 
 } = require('../controllers/cluster.controller');
 
-router.post('/update-occurrences', updateAllClusterOccurrences);
-router.get('/:countryCode/gbif', updateClusterStatusFromAPI);
+router.post('/gbif', updateClusterStatusFromAPI);
 router.post('/', updateClusterForSpecies);
 router.get('/', getSpeciesClusters);
+router.post('/update-occurrences', updateAllClusterOccurrences);
 
 module.exports = router;

--- a/backend/services/gbif.service.js
+++ b/backend/services/gbif.service.js
@@ -1,23 +1,36 @@
 const axios = require('axios');
-
+const qs = require('qs');
 const GBIF_API_BASE_URL = 'https://api.gbif.org/v1';
 
 
 /**
- * Funcion que consulta al endpoint /occurrence/search de GBIF, especificamente haciendo una busqueda especifica para ArcticFlower, donde consulto un pais especifico con su codigo ISO 3166-1 alpha-2, y solicitando unicamente occurrences que afecten a especie en estado de CR,EW y EX. Este endpoint devuelve occurrences asociados a un pais, y estos occurrences deben ser analizados para extraer nuevas especies o cambios en las especies existentes, como nuevo location en otro pais o cambios de estado.
- * @returns {Object} Array de hasta 100 occurrences de especies en estado de CR,EW y EX para el pais establecido, adicionalmente trae la cantidad de occurrences asociados a ese pais, utilizado para calcular la diferencia y consultar de forma especifica los cambios a ese pais.
- */
-exports.getGbifCountryData = async (countryCode) => {
-  const url = `${GBIF_API_BASE_URL}/occurrence/search?country=${countryCode}&limit=100&hasCoordinate=true&iucnRedListCategory=EX&iucnRedListCategory=EW&iucnRedListCategory=CR`;
-  const response = await axios.get(url);
-  return { occurrences: response.data };
+* Funcion que consulta al endpoint /occurrence/search de GBIF, especificamente haciendo una busqueda especifica para ArcticFlower, donde consulto un pais especifico con su codigo ISO 3166-1 alpha-2, y solicitando unicamente occurrences que afecten a especie en estado de CR,EW y EX. Este endpoint devuelve occurrences asociados a un pais, y estos occurrences deben ser analizados para extraer nuevas especies o cambios en las especies existentes, como nuevo location en otro pais o cambios de estado.
+* @returns {Object} Array de hasta 100 occurrences de especies en estado de CR,EW y EX para el pais establecido, adicionalmente trae la cantidad de occurrences asociados a ese pais, utilizado para calcular la diferencia y consultar de forma especifica los cambios a ese pais.
+*/
+exports.getGbifCountryData = async (countryCode, dateRangeMin, dateRangeMax, limit = 300, offset = 0) => {
+  const params = {
+    country: countryCode,
+    hasCoordinate: true,
+    iucnRedListCategory: ['EX','EW','CR'],
+    eventDate: `${dateRangeMin},${dateRangeMax}`,
+    limit,
+    offset
+  };
+  const response = await axios.get(
+    `${GBIF_API_BASE_URL}/occurrence/search`,
+    {
+      params,
+      paramsSerializer: ps => qs.stringify(ps, { arrayFormat: 'repeat' })
+    }
+  );
+  return response.data;  
 };
 
 
 /**
- * Funcion que consulta el endpoint /species/${taxonKey}/vernacularNames de GBIF, utilizada para conseguir los common_names de especies que aun no tienen.
- * @returns {Object} resultado con los vernacularNames asociados a la especie consultada con el taxonKey de GBIF.
- */
+* Funcion que consulta el endpoint /species/${taxonKey}/vernacularNames de GBIF, utilizada para conseguir los common_names de especies que aun no tienen.
+* @returns {Object} resultado con los vernacularNames asociados a la especie consultada con el taxonKey de GBIF.
+*/
 exports.getGbifSpeciesVernacularName = async (taxonKey) => {
   const url = `${GBIF_API_BASE_URL}/species/${taxonKey}/vernacularNames`;
   const response = await axios.get(url);
@@ -26,9 +39,9 @@ exports.getGbifSpeciesVernacularName = async (taxonKey) => {
 
 
 /**
- * Funcion que consulta el endpoint /species/${taxonKey}/iucnRedListCategory de GBIF, utilizada para actualizar el estado de la especie cuando no ha sido actualizada despues de cierta cantidad de tiempo.
- * @returns {Object} resultado con el estado mas reciente de la especie segun la categoria de IUCN Red List.
- */
+* Funcion que consulta el endpoint /species/${taxonKey}/iucnRedListCategory de GBIF, utilizada para actualizar el estado de la especie cuando no ha sido actualizada despues de cierta cantidad de tiempo.
+* @returns {Object} resultado con el estado mas reciente de la especie segun la categoria de IUCN Red List.
+*/
 exports.getGbifSpeciesRedListCategory = async (taxonKey) => {
   const url = `${GBIF_API_BASE_URL}/species/${taxonKey}/iucnRedListCategory`;
   const response = await axios.get(url);
@@ -37,9 +50,9 @@ exports.getGbifSpeciesRedListCategory = async (taxonKey) => {
 
 
 /**
- * Funcion que consulta el endpoint /species/${taxonKey}/media de GBIF, utilizada para conseguir los medios (imagenes, videos, documentos, etc) de especies que aun no tienen.
- * @returns {Object} resultado con un conjunto de medios de la especie, con atributos como idenitifier, titulo, descripcion y referencias.
- */
+* Funcion que consulta el endpoint /species/${taxonKey}/media de GBIF, utilizada para conseguir los medios (imagenes, videos, documentos, etc) de especies que aun no tienen.
+* @returns {Object} resultado con un conjunto de medios de la especie, con atributos como idenitifier, titulo, descripcion y referencias.
+*/
 exports.getGbifSpeciesMedia = async (taxonKey) => {
   const url = `${GBIF_API_BASE_URL}/species/${taxonKey}/media`;
   const response = await axios.get(url);

--- a/frontend/src/app/core/services/cluster.service.ts
+++ b/frontend/src/app/core/services/cluster.service.ts
@@ -21,7 +21,7 @@ export class ClusterService {
     return this.http.post(this.apiUrl, speciesData);
   }
 
-  updateClusterStatusFromAPI(countryCode: string) {
-    return this.http.get<any>(`${this.apiUrl}/${countryCode}/gbif`);
+  updateClusterStatusFromAPI(cluster: ClusterPoint) {
+    return this.http.post<any>(`${this.apiUrl}/gbif`, cluster);
   }
 }

--- a/frontend/src/app/pages/map/map.component.ts
+++ b/frontend/src/app/pages/map/map.component.ts
@@ -23,21 +23,21 @@ import countries from 'world-countries';
 
 export class MapComponent implements AfterViewInit {
   @ViewChild('globeContainer') globeContainer!: ElementRef;
-
-  //Instancia del globo, marcadores y vista movil/desktop
+  
+  //Globe instance, markers and mobile/desktop view
   private globeInstance: any;
   private markerSvg = `<svg viewBox="-4 0 36 36"><path fill="currentColor" d="M14,0 C21.732,0 28,5.641 28,12.6 C28,23.963 14,36 14,36 C14,36 0,24.064 0,12.6 C0,5.641 6.268,0 14,0 Z"></path><circle fill="black" cx="14" cy="14" r="7"></circle></svg>`;
   public isLoading: boolean = true;
   public isMobile: boolean = false;
   
-  //Marcadores y selecciones actuales
+  //Markers and current selections
   public selectedSpecies: SpeciesPoint | null = null;
   public selectedCluster: ClusterPoint | null = null;
   private clusterPoints: ClusterPoint[] = [];
   private expandedClusterId: string | null = null;
   private expandedSpeciesMarkers: SpeciesPoint[] = [];
   
-  //Sistema de busqueda
+  //Search system
   public searchTerm: string = "";
   public filteredClusters: ClusterPoint[] = [];
   public filteredSpecies: SpeciesPoint[] = [];
@@ -46,7 +46,7 @@ export class MapComponent implements AfterViewInit {
   private minSearchLength = 3;
   public daysToCheck = 14;
   
-  //Carga de media
+  //Media carrousel
   public showImageInfo: boolean = false;
   currentImageIndex = 0;
   
@@ -73,7 +73,7 @@ export class MapComponent implements AfterViewInit {
       this.spinner.hide();
     }, 1500);
   }
-
+  
   private initializeGlobe(): void {
     this.globeInstance = GLOBE.default({ animateIn: false })(this.globeContainer.nativeElement)
     .globeImageUrl('../../../assets/img/globe/earth.jpg')
@@ -167,13 +167,13 @@ export class MapComponent implements AfterViewInit {
     this.loadClusterSpecies(cluster);
     this.flyToMarker(cluster);
   }
-
+  
   checkClusterUpdate(cluster: ClusterPoint): void {
     const oneWeekAgo = new Date();
     oneWeekAgo.setDate(oneWeekAgo.getDate() - this.daysToCheck);
     if (new Date(cluster.updatedAt) < oneWeekAgo) {
       console.log("El cluster no ha sido actualizado en el plazo establecido. Se realizará una llamada a la API para actualizar datos.");
-      this.clusterService.updateClusterStatusFromAPI(cluster.country).subscribe({
+      this.clusterService.updateClusterStatusFromAPI(cluster).subscribe({
         next: resp => {
           console.log("RESPUESTA ENTERA:", resp);
           console.log("Cluster actualizado:", resp.cluster);
@@ -192,7 +192,7 @@ export class MapComponent implements AfterViewInit {
       return;
     }
   }
-
+  
   checkSpeciesUpdate(species: SpeciesPoint): void {
     const oneWeekAgo = new Date();
     oneWeekAgo.setDate(oneWeekAgo.getDate() - this.daysToCheck);
@@ -215,7 +215,7 @@ export class MapComponent implements AfterViewInit {
       return;
     }
   }
-
+  
   loadClusterSpecies(cluster: ClusterPoint): void {
     this.speciesService.getSpeciesByCountry(cluster.country).subscribe({
       next: (speciesArray: any[]) => {
@@ -304,7 +304,7 @@ export class MapComponent implements AfterViewInit {
     
     this.flyToMarker(species);
   }
-   
+  
   // Metodo para cerrar el panel lateral
   public closePanel(): void {
     this.clearCurrentSelection();
@@ -397,7 +397,7 @@ export class MapComponent implements AfterViewInit {
       );
     }
   }
-
+  
   private setupSearch(): void {
     this.searchSubject.pipe(
       debounceTime(300),
@@ -412,7 +412,7 @@ export class MapComponent implements AfterViewInit {
       })
     ).subscribe(species => this.filteredSpecies = species);
   }
-
+  
   clearCurrentSelection(): void {
     this.selectedSpecies = null;
     this.currentImageIndex = 0;
@@ -437,7 +437,7 @@ export class MapComponent implements AfterViewInit {
       this.filteredSpecies = [];
     }
   }
-
+  
   public selectSpeciesFromSearch(species: SpeciesPoint): void {
     const cluster = this.clusterPoints.find(c => 
       c.country.toUpperCase() === species.country?.toUpperCase()
@@ -451,7 +451,6 @@ export class MapComponent implements AfterViewInit {
       this.selectSpecies(species);
     }
   }
-  
   
   isCluster(result: ClusterPoint | SpeciesPoint): result is ClusterPoint {
     return 'count' in result;


### PR DESCRIPTION
Complete implementation of data update on cluster or species click. When a user clicks and a cluster(country/territory) or species, if a set amount of time has passed since last update (14 days for now), IUCN and GBIF endpoints are consulted for updated data.

This includes the entire data flow, which accounts for cases where the species doesn't exist (it's created), it exists but doesn't have a location in said country (it creates the location), the species doesn't have media, description or common_name (it's then obtained from said endpoints).